### PR TITLE
cloud-init for catatsuy/private-isu

### DIFF
--- a/private-isu/README.md
+++ b/private-isu/README.md
@@ -1,0 +1,32 @@
+# cloud-init-isucon/private-isu
+
+## Overview
+
+catatsuy/private-isuの環境を構築するためのcloud-configです。
+
+## Requirements
+
+* Ubuntu 20.04 LTSを用意してください。
+* ストレージは8GBでは不足します。16GBあれば問題ないと思います。
+* Memoryは1GBだと構築中に不足します。2GB以上あれば問題ないと思います。
+* CPUコア数は少なくても問題ないですが、多ければ構築が早く完了するはずです。
+
+
+## Usage
+
+cloud-initに対応した環境にて、アプリケーションサーバをapp.cfg、ベンチマーカーをbenchmarker.cfgにて構築します。
+
+### Bench
+
+構築が終わったらベンチマークを実行します
+
+ベンチマーカーのサーバからアプリケーションサーバにむけて実行します
+
+```sh
+cd /home/isucon/private_isu.git/benchmarker
+./bin/benchmarker -u ./userdata -t http://{競技用インスタンスのIPアドレス}/
+```
+
+## その他の情報
+
+[catatsuy/private-isu](https://github.com/catatsuy/private-isu/)をご確認ください。

--- a/private-isu/app.cfg
+++ b/private-isu/app.cfg
@@ -1,0 +1,18 @@
+#cloud-config
+
+timezone: Asia/Tokyo
+package_update: true
+packages:
+  - ansible
+  - curl
+  - git
+runcmd:
+  - |
+    set -e
+
+    GITDIR="/tmp/private-isu"
+    rm -rf ${GITDIR}
+    git clone --depth=1 https://github.com/catatsuy/private-isu.git ${GITDIR}
+    cd ${GITDIR}/provisioning/
+    sed -i 's/isu-app/localhost ansible_connection=local/' hosts
+    ansible-playbook -i hosts image/ansible/playbooks.yml --skip-tags nodejs

--- a/private-isu/benchmarker.cfg
+++ b/private-isu/benchmarker.cfg
@@ -1,0 +1,18 @@
+#cloud-config
+
+timezone: Asia/Tokyo
+package_update: true
+packages:
+  - ansible
+  - curl
+  - git
+runcmd:
+  - |
+    set -e
+
+    GITDIR="/tmp/private-isu"
+    rm -rf ${GITDIR}
+    git clone --depth=1 https://github.com/catatsuy/private-isu.git ${GITDIR}
+    cd ${GITDIR}/provisioning/
+    sed -i 's/isu-bench/localhost ansible_connection=local/' hosts
+    ansible-playbook -i hosts bench/ansible/playbooks.yml


### PR DESCRIPTION
catatsuy/private-isu のcloud-init の追加になります。
さくらのクラウドで動作確認しています。

こちらのPRがmergeされれば、AArch64でも動作するかと思います。
https://github.com/catatsuy/private-isu/pull/277