### PR TITLE
Add cloud-init for isucon11-prior

### DIFF
--- a/isucon11-prior/README.md
+++ b/isucon11-prior/README.md
@@ -24,15 +24,3 @@ cloud-initに対応した環境にて isucon11-prior.cfg を使いサーバを�
 $ sudo su - isucon
 $ ./bin/benchmarker 
 ```
-
-
-
-
-
-
-
-
-
-
-
-

--- a/isucon11-prior/README.md
+++ b/isucon11-prior/README.md
@@ -1,0 +1,38 @@
+# cloud-init-isucon/isucon11-prior
+
+## Overview
+
+isucon11事前講習([isucon11-prior](https://github.com/isucon/isucon11-prior))とほぼ同じ環境を構築するためのcloud-configです。
+
+## Requirements
+
+* Ubuntu 20.04 LTSを用意してください。
+* ストレージは8GBでは不足します。16GBあれば問題ないと思います。
+* Memoryは1GBだと構築中に不足します。2GB以上あれば問題ないと思います。
+* CPUコア数は少なくても問題ないですが、多ければ構築が早く完了するはずです。
+* 2コアで10分から15分程度かかります
+
+## Usage
+
+cloud-initに対応した環境にて isucon11-prior.cfg を使いサーバを構築します。
+
+## Bench
+
+構築が終わったらsshでログインし、ベンチマークを実行します
+
+```
+$ sudo su - isucon
+$ ./bin/benchmarker 
+```
+
+
+
+
+
+
+
+
+
+
+
+

--- a/isucon11-prior/isucon11-prior.cfg
+++ b/isucon11-prior/isucon11-prior.cfg
@@ -1,0 +1,29 @@
+#cloud-config
+
+timezone: Asia/Tokyo
+package_update: true
+packages:
+  - ansible
+  - git
+  - itamae
+  - curl
+  - software-properties-common
+runcmd:
+  - |
+    set -e
+    GITDIR="/tmp/isucon11-prior"
+
+    rm -rf ${GITDIR}
+    git clone --depth=1 -b matsuu-fix https://github.com/matsuu/isucon11-prior.git ${GITDIR}
+    (
+      cd ${GITDIR}/infra/instance
+
+      sed -i 's/apt upgrade -y/true/' cookbooks/apt/default.rb
+      sed -i "s/include_cookbook 'systemd-timesyncd'//" recipe.rb
+
+      openssl req -subj '/CN=localhost' -nodes -newkey rsa:2048 -keyout cookbooks/nginx/files/usr/local/ssl/privkey.pem -out cookbooks/nginx/files/usr/local/ssl/tls-csr.pem
+      echo "basicConstraints=critical,CA:true,pathlen:0\nsubjectAltName=DNS.1:localhost,IP.1:127.0.0.1" > cookbooks/nginx/files/usr/local/ssl/tls-extfile.txt
+      openssl x509 -in cookbooks/nginx/files/usr/local/ssl/tls-csr.pem -req -signkey cookbooks/nginx/files/usr/local/ssl/privkey.pem -sha256 -days 3650 -out cookbooks/nginx/files/usr/local/ssl/fullchain.pem -extfile cookbooks/nginx/files/usr/local/ssl/tls-extfile.txt
+      itamae local recipe.rb
+    )
+    rm -rf ${GITDIR}


### PR DESCRIPTION
[isucon11-prior](https://github.com/isucon/isucon11-prior) のcloud-init の追加になります。
さくらのクラウドで動作確認しています。

[vagrant](https://github.com/matsuu/vagrant-isucon11-prior) を参考に作りました
