### PR TITLE
remove unnecessary sql copy for isucon11 qualify

### DIFF
--- a/isucon11f/isucon11f.cfg
+++ b/isucon11f/isucon11f.cfg
@@ -27,7 +27,6 @@ runcmd:
       sed -i -e "/go-install/s/$/ `uname -s | tr 'A-Z' 'a-z'` `dpkg --print-architecture`/" roles/langs.go/tasks/main.yml
 
       # contestant
-      curl -sL https://github.com/isucon/isucon11-qualify/releases/download/public/1_InitData.sql > roles/contestant/files/initial-data.sql
       echo "basicConstraints=critical,CA:true,pathlen:0\nsubjectAltName=DNS.1:*.t.isucon.dev" > roles/contestant/files/etc/nginx/certificates/tls-extfile.txt
       openssl req -subj '/CN=*.t.isucon.dev' -nodes -newkey rsa:2048 -keyout roles/contestant/files/etc/nginx/certificates/tls-key.pem -out roles/contestant/files/etc/nginx/certificates/tls-csr.pem
       openssl x509 -in roles/contestant/files/etc/nginx/certificates/tls-csr.pem -req -signkey roles/contestant/files/etc/nginx/certificates/tls-key.pem -sha256 -days 3650 -out roles/contestant/files/etc/nginx/certificates/tls-cert.pem -extfile roles/contestant/files/etc/nginx/certificates/tls-extfile.txt


### PR DESCRIPTION
Thank you for this repository.

I found a copy of the SQL for the isucon11 qualify in the file for the isucon11 final, so I removed it.
