### PR TITLE
[isucon13]ssl接続を有効にする

### DIFF
--- a/isucon13/README.md
+++ b/isucon13/README.md
@@ -17,7 +17,7 @@ isucon13とほぼ同じ環境を構築するためのcloud-configです。
 * 構築が終わったらベンチマークを実行します
   ```sh
   sudo -i -u isucon
-  ./bench run
+  ./bench run --enable-ssl
   ```
 
 構築時のタイミングによってpowerdnsの初期化に失敗してベンチマークが正しく実行されない場合があるようです。


### PR DESCRIPTION
enable-sslオプションがないとssl接続が有効にならないようです。
```
isucon@isucon13:~$ ./bench run
2024-06-06T14:18:23.629Z	info	isupipe-benchmarker	SSL接続が無効になっています
```

```
isucon@isucon13:~$ ./bench run --enable-ssl
2024-06-06T14:19:14.845Z	info	staff-logger	bench/bench.go:172	SSL接続が有効になっています
```

https://github.com/isucon/isucon13?tab=readme-ov-file#%E3%83%99%E3%83%B3%E3%83%81%E3%83%9E%E3%83%BC%E3%82%AB%E3%83%BC%E3%81%AE%E5%AE%9F%E8%A1%8C-1